### PR TITLE
Add touchIsSupported property which checks for window.TouchEvent

### DIFF
--- a/css3d-simple-drag.js
+++ b/css3d-simple-drag.js
@@ -40,7 +40,7 @@ var SimpleDrag = function (options) {
     this.onUpdate = (this.onUpdate || function () {}).bind(this);
 
     // Set up the click handlers (without these nothing happens)
-    if (typeof window.ontouchstart !== 'undefined') {
+    if (css3d.touchIsSupported) {
         this.movable3d.el.addEventListener('touchstart', this.tap);
     }
 
@@ -58,7 +58,7 @@ _.extend(SimpleDrag.prototype, {
 
         this.offset = e.synthetic ? this.reference : this.movable3d['get' + this.animatedProperty]();
 
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             if (e.touches && e.touches.length > 1) {
                 // disable drag with two or more fingers
                 // this allows us to resize and do other things
@@ -103,7 +103,7 @@ _.extend(SimpleDrag.prototype, {
     },
 
     killEventHandlers: function () {
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             window.removeEventListener('touchmove', this.drag);
             window.removeEventListener('touchend', this.release);
         }
@@ -166,7 +166,7 @@ _.extend(SimpleDrag.prototype, {
     destroy: function () {
         this.killEventHandlers();
 
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             this.movable3d.el.removeEventListener('touchstart', this.tap);
         }
 

--- a/css3d-simple-resize.js
+++ b/css3d-simple-resize.js
@@ -26,7 +26,7 @@ var SimpleResize = function (options) {
 
     // It's important to have both events:
     // e.g. MS Surface supports both depending on touch or stylus click
-    if (typeof window.ontouchstart !== 'undefined') {
+    if (css3d.touchIsSupported) {
         this.resizable3d.el.addEventListener('touchstart', this.tap);
     }
 
@@ -72,7 +72,7 @@ _.extend(SimpleResize.prototype, {
 
         this.resizable3d.el.classList.add('resizing');
 
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             window.addEventListener('touchmove', this.drag);
             window.addEventListener('touchend', this.release);
         }
@@ -137,7 +137,7 @@ _.extend(SimpleResize.prototype, {
         this.resizable3d.style[css3d.duration] = null;
         this.resizable3d.el.classList.remove('resizing');
 
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             if (e.touches && e.touches.length < 2) {
                 window.removeEventListener('touchmove', this.pinch);
             }
@@ -175,7 +175,7 @@ _.extend(SimpleResize.prototype, {
     },
 
     destroy: function () {
-        if (typeof window.ontouchstart !== 'undefined') {
+        if (css3d.touchIsSupported) {
             this.resizable3d.el.removeEventListener('touchstart', this.tap);
         }
 

--- a/css3d.js
+++ b/css3d.js
@@ -23,7 +23,16 @@ css3d = function (selector) {
     this.getMatrix(); // set an initial value for the matrix
 };
 
+/*
+ * As of November 2018, all relevant mobile browser 
+ * (chrome, firefox, safari, opera) should define window.TouchEvent
+ * Desktop browsers generally don't, but they interprete touches as mouse events.
+ * The only Desktop Browser to define window.TouchEvent is Chrome,
+ * but it does not interprete mouse clicks as touches in turn.
+ * see https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent
+ */
 css3d.touchIsSupported = typeof window.TouchEvent !== "undefined";
+
 css3d.originMatrix = [1, 0, 0, 1, 0, 0];
 css3d.matrixRegex = new RegExp(/-?\d+\.?\d*/g);
 css3d.check = function (properties) {

--- a/css3d.js
+++ b/css3d.js
@@ -23,6 +23,7 @@ css3d = function (selector) {
     this.getMatrix(); // set an initial value for the matrix
 };
 
+css3d.touchIsSupported = typeof window.TouchEvent !== "undefined";
 css3d.originMatrix = [1, 0, 0, 1, 0, 0];
 css3d.matrixRegex = new RegExp(/-?\d+\.?\d*/g);
 css3d.check = function (properties) {


### PR DESCRIPTION
## Motivation:
`window.ontouchstart` does not exist anymore so we have to use something else in order to check
for touch support. `window.TouchEvent` seemed ok to me, but maybe there is an even better choice.