### PR TITLE
Fix bug: window event handlers sometimes not cleaned up

### DIFF
--- a/css3d-simple-resize.js
+++ b/css3d-simple-resize.js
@@ -174,7 +174,20 @@ _.extend(SimpleResize.prototype, {
         return e.clientX;
     },
 
+    killEventHandlers: function () {
+        if (css3d.touchIsSupported) {
+            window.removeEventListener('touchmove', this.drag);
+            window.removeEventListener('touchmove', this.pinch);
+            window.removeEventListener('touchend', this.release);
+        }
+
+        window.removeEventListener('mousemove', this.drag);
+        window.removeEventListener('mouseup', this.release);
+    },
+
     destroy: function () {
+        this.killEventHandlers();
+
         if (css3d.touchIsSupported) {
             this.resizable3d.el.removeEventListener('touchstart', this.tap);
         }


### PR DESCRIPTION
`SimpleDrag` called a `killEventHandlers` method in `destroy()`, but `SimpleResize` did not. Under very specific circumstances, it was possible for `SimpleResize.destroy()` to be called while it still had global window event handlers attached. This would result in DOM lookup errors for every following mousemove event.